### PR TITLE
Function split() was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.

### DIFF
--- a/utils/generate_algorithm_list.php
+++ b/utils/generate_algorithm_list.php
@@ -6,7 +6,7 @@ function __iso7064_load_algorithms() {
  global $__iso7064_algorithms;
  $algorithms_definition = dirname(__FILE__) . "/algorithms.txt";
  $data = file_get_contents($algorithms_definition);
- $lines = split("\n",$data);
+ $lines = explode("\n",$data);
  array_shift($lines); # drop header
  foreach($lines as $line) {
   if($line!='') {

--- a/utils/generate_php-iso7064.php
+++ b/utils/generate_php-iso7064.php
@@ -6,7 +6,7 @@ function __iso7064_load_algorithms() {
  global $__iso7064_algorithms;
  $algorithms_definition = dirname(__FILE__) . "/algorithms.txt";
  $data = file_get_contents($algorithms_definition);
- $lines = split("\n",$data);
+ $lines = explode("\n",$data);
  array_shift($lines); # drop header
  foreach($lines as $line) {
   if($line!='') {


### PR DESCRIPTION
The patch makes the code running on PHP version >= 7.0.0